### PR TITLE
Added Source Output to API Surface

### DIFF
--- a/src/cognitive-complexity/output.ts
+++ b/src/cognitive-complexity/output.ts
@@ -26,13 +26,13 @@ export async function getFileOrFolderOutput(entryPath: string): Promise<FileOutp
 // API
 export async function getFileOutput(filePath: string): Promise<FileOutput> {
     const fileContent = (await fsP.readFile(filePath)).toString();
-    return getSourceOutput(fileContent, filePath);
+    return getSourceOutput(fileContent, path.basename(filePath));
 }
 
 // API
-export function getSourceOutput(sourceCode: string, filePath = ''): FileOutput {
+export function getSourceOutput(sourceCode: string, fileName = ""): FileOutput {
     const parsedFile = ts.createSourceFile(
-        path.basename(filePath),
+        fileName,
         sourceCode,
         ts.ScriptTarget.Latest,
         true,

--- a/src/cognitive-complexity/output.ts
+++ b/src/cognitive-complexity/output.ts
@@ -26,10 +26,14 @@ export async function getFileOrFolderOutput(entryPath: string): Promise<FileOutp
 // API
 export async function getFileOutput(filePath: string): Promise<FileOutput> {
     const fileContent = (await fsP.readFile(filePath)).toString();
+    return getSourceOutput(fileContent, filePath);
+}
 
+// API
+export function getSourceOutput(sourceCode: string, filePath = ''): FileOutput {
     const parsedFile = ts.createSourceFile(
         path.basename(filePath),
-        fileContent,
+        sourceCode,
         ts.ScriptTarget.Latest,
         true,
     );


### PR DESCRIPTION
### Changes
The public API now contains `getSourceOutput`, which takes source code as a string, and (optionally) the file path that code came from. Its implementation was pretty much moved from `getFileOutput`, which is now defined in terms of it.

This does technically increase the public-facing API surfaces that needs to be maintained.

### Motivation
I've got some files that I'd really like to be able to use cognitive complexity analysis on, but they're not just flat `.ts` files. Instead, they're `.vue` singe file components (SFCs), so they have HTML, TS/JS, and CSS in one file. They kinda look like [this](https://codesandbox.io/s/vue?file=/src/components/HelloWorld.vue) (I didn't write that, but note the `<script>` block mid-way down the file).

Surprisingly `ccts-json` only _sometimes_ crashes on those files (which is pretty impressive that it "accidentally" parses that mess when it was only designed for typescript). Unfortunately, this does leave the files that it does crash on.

With this API extension, I was able to write a quick JS file that extracts only the script block and then feeds it into `getSourceOutput` so that only it gets scored.


### Tests
Currently the testing API is relatively simple but only tests files and folders. I'm not sure how to properly add an automated test that exercises `getSourceOutput` exclusively, however `getFileOutput` is defined in terms of it, and is still exercised on every case, so this change doesn't affect code coverage, and kinda comes with implicit trust.

Let me know if there are any better ideas and if they're necessary.