### PR TITLE
Avoid `undefined` nodes in unnamed catch blocks.

### DIFF
--- a/src/cognitive-complexity/depth.ts
+++ b/src/cognitive-complexity/depth.ts
@@ -67,13 +67,9 @@ function arrowFunction(node: ts.ArrowFunction): DepthOfChildren {
 
 function catchClause(node: ts.CatchClause): DepthOfChildren {
     const children = node.getChildren();
-
-    const variableDefinition = children[2];
-    const catchCode = children[4];
-
     return {
-        same: [variableDefinition],
-        below: [catchCode]
+        same: children.filter(child => child.kind === ts.SyntaxKind.VariableDeclaration),
+        below: children.filter(child => child.kind === ts.SyntaxKind.Block),
     };
 }
 

--- a/test/cases/38-unnamed-empty-catch.expected.json
+++ b/test/cases/38-unnamed-empty-catch.expected.json
@@ -1,0 +1,5 @@
+{
+  "38-unnamed-empty-catch.ts": {
+      "score": 1
+  }
+}

--- a/test/cases/38-unnamed-empty-catch.ts
+++ b/test/cases/38-unnamed-empty-catch.ts
@@ -1,0 +1,6 @@
+try {
+  console;
+} catch {
+  // If the session delete fails then it is likely that the session has
+  // already expired anyway so do nothing.
+}


### PR DESCRIPTION
Should fix #12 and add a relevant test case.